### PR TITLE
Equi7Grid upgrade

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Version 0.3.0
 - added more input argument checks to the data loading functions
 - added geospade as a new dependency to allow for a faster polygon masking
 - upgrade to GDAL 3 and Python 3.7
+- upgrade of Equi7Grid version
 
 Version 0.2.2
 =============

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -9,8 +9,8 @@ dependencies:
   - cartopy
   - pip
   - pip:
-    - pytileproj==0.0.12
-    - Equi7Grid==0.0.10
+    - pytileproj
+    - equi7grid
     - veranda==0.1.0
-    - geospade=0.1.1
-    - geopathfinder==0.1.1
+    - geospade
+    - geopathfinder

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,11 +34,11 @@ package_dir =
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.1a0,<3.2a0
 install_requires =
-    pytileproj==0.0.12
-    Equi7Grid==0.0.10
+    pytileproj
+    equi7grid
     veranda==0.1.0
-    geopathfinder==0.1.1
-    geospade==0.1.1
+    geopathfinder
+    geospade
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4


### PR DESCRIPTION
- upgraded equi7grid version (https://github.com/TUW-GEO/yeoda/issues/16)
- unpinned most dependencies (latest version can be used)