### PR TITLE
D fix read the docs build & update README with code snippets

### DIFF
--- a/.github/workflows/update_markdown.yml
+++ b/.github/workflows/update_markdown.yml
@@ -18,5 +18,5 @@ jobs:
         git commit -m "d Doco changes" -a  || echo "nothing to commit"
         remote="https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
         branch="${GITHUB_REF:11}"
-        echo "would push to ${branch}"
+        git push "${remote}" ${branch} || echo "nothing to push"
       shell: bash

--- a/.github/workflows/update_markdown.yml
+++ b/.github/workflows/update_markdown.yml
@@ -1,0 +1,22 @@
+name: update-markdown-snippets
+on:
+  push:
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run MarkdownSnippets
+      run: |
+        dotnet tool install --global MarkdownSnippets.Tool
+        mdsnippets ${GITHUB_WORKSPACE}
+      shell: bash
+    - name: Push changes
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git commit -m "d Doco changes" -a  || echo "nothing to commit"
+        remote="https://${GITHUB_ACTOR}:${{secrets.GITHUB_TOKEN}}@github.com/${GITHUB_REPOSITORY}.git"
+        branch="${GITHUB_REF:11}"
+        echo "would push to ${branch}"
+      shell: bash

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+
 sphinx:
   configuration: docs/conf.py
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
 ## Contents
 
   * [Description](#description)
-  * [Limitations and Outlook](#limitations-and-outlook)
+  * [Limitations and outlook](#limitations-and-outlook)
   * [Installation](#installation)
-    * [pip](#pip)
-    * [conda](#conda)
+    * [Pip](#pip)
+    * [Conda](#conda)
   * [Examples](#examples)
-    * [Loading data from TIFF Files](#loading-data-from-tiff-files)
+    * [Loading data from GeoTIFF files](#loading-data-from-geotiff-files)
     * [Read raster data by pixel coordinates](#read-raster-data-by-pixel-coordinates)
-    * [Read rasta data by bounding box](#read-rasta-data-by-bounding-box)
+    * [Read raster data by bounding box](#read-raster-data-by-bounding-box)
   * [Contribution](#contribution)
   * [Citation](#citation)<!-- endToc -->
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 *Earth Observation (EO) data, I must read.*
 
+toc
+
 ## Description
 *yeoda* stands for **y**our **e**arth **o**bservation **d**ata **a**ccess and provides lower and higher-level data cube 
 classes to work with well-defined and structured earth observation data. These data cubes allow to filter, split and load data independently from the way the data is structured on the hard disk. Once the data structure is known to *yeoda*, it offers a user-friendly interface to access the data with the aforementioned operations.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ coordinates or geometry definitions.
 ### Loading data from TIFF Files
 You can create a data cube from a collection of tiff files, by passing them into the constructor of the `EODataCube` and
 specifying the type of naming convention you want to use via the `filename_class` parameters. This can take any 
-`SmartFilename` class, see [geopathfinder] (https://github.com/TUW-GEO/geopathfinder) for details. The `dimensions` parameter
+`SmartFilename` class, see [*geopathfinder*](https://github.com/TUW-GEO/geopathfinder) for details. The `dimensions` parameter
 defines the columns you want to read into the data cube's inventory and the values for these are usually parsed from the
 `SmartFilename`. The `sdim_name` defines the spatial dimension.
 
@@ -115,7 +115,7 @@ dc.filter_spatially_by_tilename('E042N012T6', inplace=True, use_grid=False)
 ### Read raster data by pixel coordinates
 The data cube's `load_by_pixels` allows you to read rasta data from specifying a region of interest in pixels. It will
 automatically crop it the requested size and handle tile boundaries. The `dtype` parameter determines the data type the
-function will return, in this case a *numpy* array (see [numpy](https://numpy.org/) for details).
+function will return, in this case a numpy array (see [numpy](https://numpy.org/) for details).
 
 <!-- snippet: data_cube_load_numpy_by_pixels -->
 <a id='snippet-data_cube_load_numpy_by_pixels'></a>
@@ -128,7 +128,7 @@ data = dc.load_by_pixels(970, 246, row_size=10, col_size=16, dtype='numpy')
 ### Read rasta data by bounding box
 Using the data cube's `load_by_geom` you can specify for instance a bounding box geometry and *yeoda* will load and 
 return the raster data covered by it. The `dtype` parameters determines the data type that will be returned, in this
-example a *numpy* array (see [numpy](https://numpy.org/) for details.
+example a numpy array (see [numpy](https://numpy.org/) for details).
 
 <!-- snippet: data_cube_load_numpy_by_bbox -->
 <a id='snippet-data_cube_load_numpy_by_bbox'></a>

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ how to bbox
 <a id='snippet-data_cube_load_numpy_by_bbox'></a>
 ```py
 bbox = [(4323250, 1309750), (4331250, 1314750)]
-data = dc.load_by_geom(self.bbox, dtype='numpy')
+data = dc.load_by_geom(bbox, dtype='numpy')
 ```
 <sup><a href='/tests/test_loading.py#L416-L419' title='Snippet source file'>snippet source</a> | <a href='#snippet-data_cube_load_numpy_by_bbox' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ tiles, e.g. you can only load data from one tile and one band. This will change 
 Most changes will take place in *veranda* and *geospade*, so the actual interface to the data given by *yeoda* should stay approximately the same.
 
 ## Installation
-The package can be either installed via pip or if you solely want to work with *yeoda* or contribute, we recommend to 
-install it as a conda environment. If you work already with your own environment, please have look at ``conda_env.yml`` or ``setup.cfg`` for the required dependencies.
+The package can be either installed via pip or if you solely want to work with *yeoda* or contribute, we recommend installing
+it as a conda environment. If you work already with your own environment, please have look at ``conda_env.yml`` or ``setup.cfg`` for the required dependencies.
 
 ### pip
 To install *yeoda* via pip in your own environment, use:
 ```
 pip install yeoda
 ```
-**ATTENTION**: Packages like *gdal*, *cartopy*, or *geopandas* need more OS support and have more dependencies then other packages and can therefore not be installed solely via pip.
+**ATTENTION**: Packages like *gdal*, *cartopy*, or *geopandas* need more OS support and have more dependencies than other packages and can therefore not be installed solely via pip.
 Thus, for a fresh setup, an existing environment with the conda dependencies listed in ``conda_env.yml`` is expected.
 To create such an environment, you can run:
 ```
@@ -73,9 +73,15 @@ python setup.py test
 to run the test suite.
 
 ## Examples
-TODO [BR 03.03.2022]: Write proper example description - I'm testing snippets just now
+This section demonstrates basic usage of a *yeoda* datacube, specifically how to load raster data and read it using pixel 
+coordinates or geometry definitions.
 
-how to load
+### Loading data from TIFF Files
+You can create a data cube from a collection of tiff files, by passing them into the constructor of the `EODataCube` and
+specifying the type of naming convention you want to use via the `filename_class` parameters. This can take any 
+`SmartFilename` class, see [geopathfinder] (https://github.com/TUW-GEO/geopathfinder) for details. The `dimensions` parameter
+defines the columns you want to read into the data cube's inventory and the values for these are usually parsed from the
+`SmartFilename`. The `sdim_name` defines the spatial dimension.
 
 <!-- snippet: create_and_filter_datacube -->
 <a id='snippet-create_and_filter_datacube'></a>
@@ -91,7 +97,10 @@ dc.filter_spatially_by_tilename('E042N012T6', inplace=True, use_grid=False)
 <sup><a href='/tests/test_loading.py#L82-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-create_and_filter_datacube' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-how to pixel
+### Read raster data by pixel coordinates
+The data cube's `load_by_pixels` allows you to read rasta data from specifying a region of interest in pixels. It will
+automatically crop it the requested size and handle tile boundaries. The `dtype` parameter determines the data type the
+function will return, in this case a *numpy* array (see [numpy](https://numpy.org/) for details).
 
 <!-- snippet: data_cube_load_numpy_by_pixels -->
 <a id='snippet-data_cube_load_numpy_by_pixels'></a>
@@ -101,7 +110,10 @@ data = dc.load_by_pixels(970, 246, row_size=10, col_size=16, dtype='numpy')
 <sup><a href='/tests/test_loading.py#L269-L271' title='Snippet source file'>snippet source</a> | <a href='#snippet-data_cube_load_numpy_by_pixels' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-how to bbox
+### Read rasta data by bounding box
+Using the data cube's `load_by_geom` you can specify for instance a bounding box geometry and *yeoda* will load and 
+return the raster data covered by it. The `dtype` parameters determines the data type that will be returned, in this
+example a *numpy* array (see [numpy](https://numpy.org/) for details.
 
 <!-- snippet: data_cube_load_numpy_by_bbox -->
 <a id='snippet-data_cube_load_numpy_by_bbox'></a>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,46 @@ python setup.py test
 ```
 to run the test suite.
 
+## Examples
+TODO [BR 03.03.2022]: Write proper example description - I'm testing snippets just now
+
+how to load
+
+<!-- snippet: create_and_filter_datacube -->
+<a id='snippet-create_and_filter_datacube'></a>
+```py
+dc = EODataCube(filepaths=filepaths, filename_class=SgrtFilename,
+                dimensions=['time', 'var_name', 'pol', 'tile_name', 'orbit_direction'], sdim_name="tile_name")
+
+dc.filter_by_dimension('VV', name='pol', inplace=True)
+dc.filter_by_dimension('SIG0', name='var_name', inplace=True)
+dc.filter_by_dimension('D', name='orbit_direction', inplace=True)
+dc.filter_spatially_by_tilename('E042N012T6', inplace=True, use_grid=False)
+```
+<sup><a href='/tests/test_loading.py#L82-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-create_and_filter_datacube' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+how to pixel
+
+<!-- snippet: data_cube_load_numpy_by_pixels -->
+<a id='snippet-data_cube_load_numpy_by_pixels'></a>
+```py
+data = dc.load_by_pixels(self.row, self.col, row_size=self.row_size, col_size=self.col_size, dtype='numpy')
+```
+<sup><a href='/tests/test_loading.py#L268-L270' title='Snippet source file'>snippet source</a> | <a href='#snippet-data_cube_load_numpy_by_pixels' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+how to bbox
+
+<!-- snippet: data_cube_load_numpy_by_bbox -->
+<a id='snippet-data_cube_load_numpy_by_bbox'></a>
+```py
+data = dc.load_by_geom(self.bbox, dtype='numpy')
+```
+<sup><a href='/tests/test_loading.py#L414-L416' title='Snippet source file'>snippet source</a> | <a href='#snippet-data_cube_load_numpy_by_bbox' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+
 ## Contribution
 We are happy if you want to contribute. Please raise an issue explaining what
 is missing or if you find a bug. We will also gladly accept pull requests

--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@
 
 *Earth Observation (EO) data, I must read.*
 
-toc
+<!-- toc -->
+## Contents
+
+  * [Description](#description)
+  * [Limitations and Outlook](#limitations-and-outlook)
+  * [Installation](#installation)
+    * [pip](#pip)
+    * [conda](#conda)
+  * [Examples](#examples)
+    * [Loading data from TIFF Files](#loading-data-from-tiff-files)
+    * [Read raster data by pixel coordinates](#read-raster-data-by-pixel-coordinates)
+    * [Read rasta data by bounding box](#read-rasta-data-by-bounding-box)
+  * [Contribution](#contribution)
+  * [Citation](#citation)<!-- endToc -->
 
 ## Description
 *yeoda* stands for **y**our **e**arth **o**bservation **d**ata **a**ccess and provides lower and higher-level data cube 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ how to pixel
 <!-- snippet: data_cube_load_numpy_by_pixels -->
 <a id='snippet-data_cube_load_numpy_by_pixels'></a>
 ```py
-data = dc.load_by_pixels(self.row, self.col, row_size=self.row_size, col_size=self.col_size, dtype='numpy')
+data = dc.load_by_pixels(970, 246, row_size=10, col_size=16, dtype='numpy')
 ```
-<sup><a href='/tests/test_loading.py#L268-L270' title='Snippet source file'>snippet source</a> | <a href='#snippet-data_cube_load_numpy_by_pixels' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/tests/test_loading.py#L269-L271' title='Snippet source file'>snippet source</a> | <a href='#snippet-data_cube_load_numpy_by_pixels' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 how to bbox
@@ -106,9 +106,10 @@ how to bbox
 <!-- snippet: data_cube_load_numpy_by_bbox -->
 <a id='snippet-data_cube_load_numpy_by_bbox'></a>
 ```py
+bbox = [(4323250, 1309750), (4331250, 1314750)]
 data = dc.load_by_geom(self.bbox, dtype='numpy')
 ```
-<sup><a href='/tests/test_loading.py#L414-L416' title='Snippet source file'>snippet source</a> | <a href='#snippet-data_cube_load_numpy_by_bbox' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/tests/test_loading.py#L416-L419' title='Snippet source file'>snippet source</a> | <a href='#snippet-data_cube_load_numpy_by_bbox' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and [*geospade*](https://github.com/TUW-GEO/geospade) (raster and vector geometr
 Moreover, another very important part of *yeoda* is that it deals with pre-defined grids like the [*Equi7Grid*](https://github.com/TUW-GEO/Equi7Grid) or the [*LatLonGrid*](https://github.com/TUW-GEO/latlongrid).
 These grid packages can simplify and speed up spatial operations to identify tiles/files of interest (e.g, bounding box request by a user).
 
-## Limitations and Outlook
+## Limitations and outlook
 At the moment the functionality of *yeoda* is limited in terms of flexibility with different file types, bands and 
 tiles, e.g. you can only load data from one tile and one band. This will change in the future by allowing to load data also independently from tile boundaries, bands and file types.
 Most changes will take place in *veranda* and *geospade*, so the actual interface to the data given by *yeoda* should stay approximately the same.
@@ -42,7 +42,7 @@ Most changes will take place in *veranda* and *geospade*, so the actual interfac
 The package can be either installed via pip or if you solely want to work with *yeoda* or contribute, we recommend installing
 it as a conda environment. If you work already with your own environment, please have look at ``conda_env.yml`` or ``setup.cfg`` for the required dependencies.
 
-### pip
+### Pip
 To install *yeoda* via pip in your own environment, use:
 ```
 pip install yeoda
@@ -54,7 +54,7 @@ To create such an environment, you can run:
 conda create -n "yeoda" -c conda-forge python=3.7 gdal=3.0.2 geopandas cartopy
 ```
 
-### conda
+### Conda
 The packages also comes along with a pre-defined conda environment (``conda_env.yml``). 
 This is especially recommended if you want to contribute to the project.
 The following script will install miniconda and setup the environment on a UNIX
@@ -91,11 +91,11 @@ to run the test suite.
 This section demonstrates basic usage of a *yeoda* datacube, specifically how to load raster data and read it using pixel 
 coordinates or geometry definitions.
 
-### Loading data from TIFF Files
-You can create a data cube from a collection of tiff files, by passing them into the constructor of the `EODataCube` and
+### Loading data from GeoTIFF files
+You can create a datacube from a collection of GeoTIFF files, by passing them into the constructor of the `EODataCube` and
 specifying the type of naming convention you want to use via the `filename_class` parameters. This can take any 
 `SmartFilename` class, see [*geopathfinder*](https://github.com/TUW-GEO/geopathfinder) for details. The `dimensions` parameter
-defines the columns you want to read into the data cube's inventory and the values for these are usually parsed from the
+defines the columns you want to read into the datacube's inventory and the values for these are usually parsed from the
 `SmartFilename`. The `sdim_name` defines the spatial dimension.
 
 <!-- snippet: create_and_filter_datacube -->
@@ -113,7 +113,7 @@ dc.filter_spatially_by_tilename('E042N012T6', inplace=True, use_grid=False)
 <!-- endSnippet -->
 
 ### Read raster data by pixel coordinates
-The data cube's `load_by_pixels` allows you to read rasta data from specifying a region of interest in pixels. It will
+The datacube's `load_by_pixels` allows you to read raster data from specifying a region of interest in pixels. It will
 automatically crop it the requested size and handle tile boundaries. The `dtype` parameter determines the data type the
 function will return, in this case a numpy array (see [numpy](https://numpy.org/) for details).
 
@@ -125,8 +125,8 @@ data = dc.load_by_pixels(970, 246, row_size=10, col_size=16, dtype='numpy')
 <sup><a href='/tests/test_loading.py#L269-L271' title='Snippet source file'>snippet source</a> | <a href='#snippet-data_cube_load_numpy_by_pixels' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-### Read rasta data by bounding box
-Using the data cube's `load_by_geom` you can specify for instance a bounding box geometry and *yeoda* will load and 
+### Read raster data by bounding box
+Using the datacube's `load_by_geom` you can specify for instance a bounding box geometry and *yeoda* will load and 
 return the raster data covered by it. The `dtype` parameters determines the data type that will be returned, in this
 example a numpy array (see [numpy](https://numpy.org/) for details).
 

--- a/mdsnippets.json
+++ b/mdsnippets.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://raw.githubusercontent.com/SimonCropp/MarkdownSnippets/master/schema.json",
+  "ExcludeDirectories": [ "target" ],
+  "Convention": "InPlaceOverwrite",
+  "TocLevel": 5
+}

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -265,8 +265,9 @@ class LoadingPixelsTester(LoadingTester):
         data = dc.load_by_pixels(self.row, self.col, dtype='numpy')
         assert np.array_equal(self.ref_np_ar, data)
 
+        # inlining commong variables so the example code snippets can be copy pasted
         # begin-snippet: data_cube_load_numpy_by_pixels
-        data = dc.load_by_pixels(self.row, self.col, row_size=self.row_size, col_size=self.col_size, dtype='numpy')
+        data = dc.load_by_pixels(970, 246, row_size=10, col_size=16, dtype='numpy')
         # end-snippet
         assert np.array_equal(self.ref_np_ar_area, data)
 
@@ -411,7 +412,9 @@ class LoadingGeomTester(LoadingTester):
         """ Tests loading of a Numpy array from GeoTIFF files by a bounding box. """
 
         dc = self._create_loadable_dc(self.gt_filepaths)
+        # inlining commong variables so the example code snippets can be copy pasted
         # begin-snippet: data_cube_load_numpy_by_bbox
+        bbox = [(4323250, 1309750), (4331250, 1314750)]
         data = dc.load_by_geom(self.bbox, dtype='numpy')
         # end-snippet
         assert np.array_equal(self.ref_np_ar_area, data)

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -415,7 +415,7 @@ class LoadingGeomTester(LoadingTester):
         # inlining commong variables so the example code snippets can be copy pasted
         # begin-snippet: data_cube_load_numpy_by_bbox
         bbox = [(4323250, 1309750), (4331250, 1314750)]
-        data = dc.load_by_geom(self.bbox, dtype='numpy')
+        data = dc.load_by_geom(bbox, dtype='numpy')
         # end-snippet
         assert np.array_equal(self.ref_np_ar_area, data)
 

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -79,7 +79,7 @@ class LoadingTester(unittest.TestCase):
         Creates a data cube and filters it so that only the temporal dimension is left for loading data
         appropriately.
         """
-
+        # begin-snippet: create_and_filter_datacube
         dc = EODataCube(filepaths=filepaths, filename_class=SgrtFilename,
                         dimensions=['time', 'var_name', 'pol', 'tile_name', 'orbit_direction'], sdim_name="tile_name")
 
@@ -87,7 +87,7 @@ class LoadingTester(unittest.TestCase):
         dc.filter_by_dimension('SIG0', name='var_name', inplace=True)
         dc.filter_by_dimension('D', name='orbit_direction', inplace=True)
         dc.filter_spatially_by_tilename('E042N012T6', inplace=True, use_grid=False)
-
+        # end-snippet
         return dc
 
 
@@ -265,7 +265,9 @@ class LoadingPixelsTester(LoadingTester):
         data = dc.load_by_pixels(self.row, self.col, dtype='numpy')
         assert np.array_equal(self.ref_np_ar, data)
 
+        # begin-snippet: data_cube_load_numpy_by_pixels
         data = dc.load_by_pixels(self.row, self.col, row_size=self.row_size, col_size=self.col_size, dtype='numpy')
+        # end-snippet
         assert np.array_equal(self.ref_np_ar_area, data)
 
     def test_load_gt2xarray_by_pixels(self):
@@ -409,7 +411,9 @@ class LoadingGeomTester(LoadingTester):
         """ Tests loading of a Numpy array from GeoTIFF files by a bounding box. """
 
         dc = self._create_loadable_dc(self.gt_filepaths)
+        # begin-snippet: data_cube_load_numpy_by_bbox
         data = dc.load_by_geom(self.bbox, dtype='numpy')
+        # end-snippet
         assert np.array_equal(self.ref_np_ar_area, data)
 
     def test_load_gt2xarray_by_geom(self):

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -116,7 +116,7 @@ class LoadingCoordsTester(LoadingTester):
         self.y = 1314750.
         dimensions = ["time", "y", "x"]
 
-        self.ref_np_ar = (np.array([[[row + col]*4]]).T + np.arange(0, 4)[:, None, None]).astype(float)
+        self.ref_np_ar = (np.array([[[row + col] * 4]]).T + np.arange(0, 4)[:, None, None]).astype(float)
         xr_ar = xr.DataArray(data=da.array(self.ref_np_ar.astype(float)).rechunk((1, 1, 1)),
                              coords={'time': self.timestamps, 'y': [self.y], 'x': [self.x]},
                              dims=['time', 'y', 'x'])
@@ -238,24 +238,26 @@ class LoadingPixelsTester(LoadingTester):
         sres = 500.
         dimensions = ["time", "y", "x"]
 
-        self.ref_np_ar = (np.array([[[self.row + self.col]*4]]).T + np.arange(0, 4)[:, None, None]).astype(float)
+        self.ref_np_ar = (np.array([[[self.row + self.col] * 4]]).T + np.arange(0, 4)[:, None, None]).astype(float)
         xr_ar = xr.DataArray(data=self.ref_np_ar.astype(float),
                              coords={'time': self.timestamps, 'y': [y], 'x': [x]},
                              dims=['time', 'y', 'x'])
         self.ref_xr_ds = xr.Dataset(data_vars={'1': xr_ar})
         self.ref_pd_df = self.ref_xr_ds.to_dataframe().reset_index().sort_values(dimensions).set_index(dimensions)
-        rows, cols = np.meshgrid(np.arange(self.row, self.row+self.row_size),
-                                 np.arange(self.col, self.col+self.col_size), indexing='ij')
+        rows, cols = np.meshgrid(np.arange(self.row, self.row + self.row_size),
+                                 np.arange(self.col, self.col + self.col_size), indexing='ij')
         xs = np.arange(x, x + self.col_size * sres, sres)
         ys = np.arange(y, y - self.row_size * sres, -sres)
         base_np_ar_2D = rows + cols
-        base_np_ar = np.stack([base_np_ar_2D]*4, axis=0)
+        base_np_ar = np.stack([base_np_ar_2D] * 4, axis=0)
         self.ref_np_ar_area = (base_np_ar + np.arange(0, 4)[:, None, None]).astype(float)
-        xr_ar = xr.DataArray(data=da.array(self.ref_np_ar_area.astype(float)).rechunk((1, self.row_size, self.col_size)),
-                             coords={'time': self.timestamps, 'y': ys, 'x': xs},
-                             dims=['time', 'y', 'x'])
+        xr_ar = xr.DataArray(
+            data=da.array(self.ref_np_ar_area.astype(float)).rechunk((1, self.row_size, self.col_size)),
+            coords={'time': self.timestamps, 'y': ys, 'x': xs},
+            dims=['time', 'y', 'x'])
         self.ref_xr_ds_area = xr.Dataset(data_vars={'1': xr_ar})
-        self.ref_pd_df_area = self.ref_xr_ds_area.to_dataframe().reset_index().sort_values(dimensions).set_index(dimensions)
+        self.ref_pd_df_area = self.ref_xr_ds_area.to_dataframe().reset_index().sort_values(dimensions).set_index(
+            dimensions)
 
     def test_load_gt2numpy_by_pixels(self):
         """ Tests loading of a Numpy array from GeoTIFF files by pixel coordinates. """
@@ -265,7 +267,11 @@ class LoadingPixelsTester(LoadingTester):
         data = dc.load_by_pixels(self.row, self.col, dtype='numpy')
         assert np.array_equal(self.ref_np_ar, data)
 
-        # inlining common variables so the example code snippets can be copy pasted
+        data = dc.load_by_pixels(self.row, self.col, row_size=self.row_size, col_size=self.col_size, dtype='numpy')
+        assert np.array_equal(self.ref_np_ar_area, data)
+
+    def test_load_by_pixels_doc_example(self):
+        dc = self._create_loadable_dc(self.gt_filepaths)
         # begin-snippet: data_cube_load_numpy_by_pixels
         data = dc.load_by_pixels(970, 246, row_size=10, col_size=16, dtype='numpy')
         # end-snippet
@@ -388,10 +394,10 @@ class LoadingGeomTester(LoadingTester):
         # defines bounding box being partially outside the tile (lower right corner)
         x_lr = 4800000.0
         y_lr = 1200000.0
-        x_min = x_lr - col_size*sres
-        x_max = x_lr + 2*col_size*sres
-        y_min = y_lr - 2*row_size*sres
-        y_max = y_lr + row_size*sres
+        x_min = x_lr - col_size * sres
+        x_max = x_lr + 2 * col_size * sres
+        y_min = y_lr - 2 * row_size * sres
+        y_max = y_lr + row_size * sres
         self.partial_outside_bbox = [(x_min, y_min), (x_max, y_max)]
         self.outside_bbox = [(0, 0), (1, 1)]
 
@@ -400,19 +406,23 @@ class LoadingGeomTester(LoadingTester):
         xs = np.arange(x, x + (col_size + 1) * sres, sres)
         ys = np.arange(y, y - (row_size + 1) * sres, -sres)
         base_np_ar_2D = rows + cols
-        base_np_ar = np.stack([base_np_ar_2D]*4, axis=0)
+        base_np_ar = np.stack([base_np_ar_2D] * 4, axis=0)
         self.ref_np_ar_area = (base_np_ar + np.arange(0, 4)[:, None, None]).astype(float)
         xr_ar = xr.DataArray(data=da.array(self.ref_np_ar_area.astype(float)).rechunk((1, row_size, col_size)),
                              coords={'time': self.timestamps, 'y': ys, 'x': xs},
                              dims=['time', 'y', 'x'])
         self.ref_xr_ds_area = xr.Dataset(data_vars={'1': xr_ar})
-        self.ref_pd_df_area = self.ref_xr_ds_area.to_dataframe().reset_index().sort_values(dimensions).set_index(dimensions)
+        self.ref_pd_df_area = self.ref_xr_ds_area.to_dataframe().reset_index().sort_values(dimensions).set_index(
+            dimensions)
 
     def test_load_gt2numpy_by_geom(self):
         """ Tests loading of a Numpy array from GeoTIFF files by a bounding box. """
-
         dc = self._create_loadable_dc(self.gt_filepaths)
-        # inlining common variables so the example code snippets can be copy pasted
+        data = dc.load_by_geom(self.bbox, dtype='numpy')
+        assert np.array_equal(self.ref_np_ar_area, data)
+
+    def test_load_by_bbox_doc_example(self):
+        dc = self._create_loadable_dc(self.gt_filepaths)
         # begin-snippet: data_cube_load_numpy_by_bbox
         bbox = [(4323250, 1309750), (4331250, 1314750)]
         data = dc.load_by_geom(bbox, dtype='numpy')
@@ -500,4 +510,3 @@ class LoadingGeomTester(LoadingTester):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -265,7 +265,7 @@ class LoadingPixelsTester(LoadingTester):
         data = dc.load_by_pixels(self.row, self.col, dtype='numpy')
         assert np.array_equal(self.ref_np_ar, data)
 
-        # inlining commong variables so the example code snippets can be copy pasted
+        # inlining common variables so the example code snippets can be copy pasted
         # begin-snippet: data_cube_load_numpy_by_pixels
         data = dc.load_by_pixels(970, 246, row_size=10, col_size=16, dtype='numpy')
         # end-snippet
@@ -412,7 +412,7 @@ class LoadingGeomTester(LoadingTester):
         """ Tests loading of a Numpy array from GeoTIFF files by a bounding box. """
 
         dc = self._create_loadable_dc(self.gt_filepaths)
-        # inlining commong variables so the example code snippets can be copy pasted
+        # inlining common variables so the example code snippets can be copy pasted
         # begin-snippet: data_cube_load_numpy_by_bbox
         bbox = [(4323250, 1309750), (4331250, 1314750)]
         data = dc.load_by_geom(bbox, dtype='numpy')


### PR DESCRIPTION
Giving examples, via code snippets, is a quick way to show how *yeoda* is to be used. By grabbing them directly from our unit-test suite, we make sure that the example code is working. Also changed the build environment for read the docs from conda to mamba because we use a lot of conda-forge packages, and this way we can save memory and build time, which hopefully will fix the read the docs build.